### PR TITLE
user#update 実装

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -53,3 +53,7 @@ p,span {
 body{
   margin-top:96px;
 }
+
+li {
+  list-style: none;
+}

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -67,6 +67,6 @@ class Users::RegistrationsController < Devise::RegistrationsController
   end
 
   def configure_account_update_params
-    devise_parameter_sanitizer.permit(:account_update, keys: [:name, :email, :account])
+    devise_parameter_sanitizer.permit(:account_update, keys: [:name, :email, :password, :password_confirmation])
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -18,6 +18,7 @@ class UsersController < ApplicationController
 
   # GET /users/1/edit
   def edit
+    @user = User.find(current_user.id)
   end
 
   # POST /users or /users.json
@@ -46,6 +47,8 @@ class UsersController < ApplicationController
         format.json { render json: @user.errors, status: :unprocessable_entity }
       end
     end
+
+    current_user.update_with_password(user_params)
   end
 
   # DELETE /users/1 or /users/1.json
@@ -70,8 +73,7 @@ class UsersController < ApplicationController
       @user = User.find(params[:id])
     end
 
-    # Only allow a list of trusted parameters through.
     def user_params
-      params.require(:user).permit(:string, :string, :string, :boolean)
+  	  params.require(:user).permit(:name, :email, :password, :password_confirmation)
     end
 end

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -3,31 +3,31 @@
   <div class="card-body">
     <h3 class="mt-1 mb-3">アカウントを作成</h3>
     <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
-    <%= render "devise/shared/error_messages", resource: resource %>
+      <%= render "devise/shared/error_messages", resource: resource %>
 
-    <div class="form-group">
-      <%= f.label :name, "ニックネーム", class: "form-label" %>
-      <%= f.text_field :name, autofocus: true, autocomplete: "email", class: "form-control" %>
-    </div>
+      <div class="form-group">
+        <%= f.label :name, "ユーザー名", class: "form-label" %>
+        <%= f.text_field :name, autofocus: true, autocomplete: "email", class: "form-control" %>
+      </div>
 
-    <div class="form-group">
-      <%= f.label :email, "メールアドレス", class: "form-label" %>
-      <%= f.email_field :email, autocomplete: "email", class: "form-control" %>
-    </div>
+      <div class="form-group">
+        <%= f.label :email, "メールアドレス", class: "form-label" %>
+        <%= f.email_field :email, autocomplete: "email", class: "form-control" %>
+      </div>
 
-    <div class="form-group">
-      <%= f.label :password, "パスワード (%s文字以上)"%@minimum_password_length, class: "form-label" %>
-      <%= f.password_field :password, class: "form-control" %>
-    </div>
+      <div class="form-group">
+        <%= f.label :password, "パスワード (%s文字以上)"%@minimum_password_length, class: "form-label" %>
+        <%= f.password_field :password, class: "form-control" %>
+      </div>
 
-    <div class="form-group">
-      <%= f.label :password_confirmation, "もう一度パスワードを入力してください", class: "form-label" %>
-      <%= f.password_field :password_confirmation, class: "form-control" %>
-    </div>
+      <div class="form-group">
+        <%= f.label :password_confirmation, "もう一度パスワードを入力してください", class: "form-label" %>
+        <%= f.password_field :password_confirmation, class: "form-control" %>
+      </div>
 
-    <div class="actions">
-      <%= f.submit "アカウントを作成する", class: "btn btn-primary btn-block" %>
-    </div>
+      <div class="actions">
+        <%= f.submit "アカウントを作成する", class: "btn btn-primary btn-block" %>
+      </div>
     <% end %>
     <div class="mt-2">
       すでにアカウントをお持ちの方は <%= link_to "こちら", new_user_session_path %>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -11,7 +11,11 @@
           <li class="nav-item"><a class="nav-link"href="#">投稿一覧</a></li>
           <li class="nav-item"><a class="nav-link" href="#">新規投稿</a></li>
           <li class="nav-item"><a class="nav-link" href="#">スキル登録</a></li>
-          <li class="nav-item"><a class="nav-link" href="#">ユーザー設定</a></li>
+          <li class="nav-item">
+            <%= link_to edit_user_path(current_user), method: :get, class:"nav-link" do %>
+              ユーザー設定
+            <% end %>
+          </li>
           <li class="nav-item">
             <%= link_to destroy_user_session_path, method: :delete, class:"nav-link" do %>
               ログアウト

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,43 +1,31 @@
-<h2>Edit <%= resource_name.to_s.humanize %></h2>
+<div class="card container">
+  <div class="card-body">
+    <h3 class="text-center">ユーザー設定</h3>
+  	<%= form_with model: @user, url: user_path(@user), method: :patch, local: true do |f| %>
 
-<%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
+      <div class="form-group row">
+        <%= f.label :name, "ユーザー名", class: "form-label col-5" %>
+        <%= f.text_field :name, autofocus: true, autocomplete: "email", class: "form-control col-7" %>
+      </div>
 
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
-  </div>
+      <div class="form-group row">
+        <%= f.label :email, "メールアドレス", class: "form-label col-5" %>
+        <%= f.email_field :email, autocomplete: "email", class: "form-control col-7" %>
+      </div>
 
-  <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
-    <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
-  <% end %>
+      <div class="form-group row">
+        <%= f.label :password, "パスワード", class: "form-label col-5" %>
+        <%= f.password_field :password, autocomplete: "new-password", class: "form-control col-7" %>
+      </div>
 
-  <div class="field">
-    <%= f.label :password %> <i>(leave blank if you don't want to change it)</i><br />
-    <%= f.password_field :password, autocomplete: "new-password" %>
-    <% if @minimum_password_length %>
-      <br />
-      <em><%= @minimum_password_length %> characters minimum</em>
+      <div class="form-group row">
+        <%= f.label :password_confirmation, "もう一度パスワードを入力してください", class: "form-label col-5" %>
+        <%= f.password_field :password_confirmation, autocomplete: "new-password", class: "form-control col-7" %>
+      </div>
+
+      <div class="actions row">
+      <div class="col-5"></div>
+        <%= f.submit "変更", class: "btn btn-primary btn-block col-2" %>
+      </div>
     <% end %>
   </div>
-
-  <div class="field">
-    <%= f.label :password_confirmation %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
-  </div>
-
-  <div class="field">
-    <%= f.label :current_password %> <i>(we need your current password to confirm your changes)</i><br />
-    <%= f.password_field :current_password, autocomplete: "current-password" %>
-  </div>
-
-  <div class="actions">
-    <%= f.submit "Update" %>
-  </div>
-<% end %>
-
-<h3>Cancel my account</h3>
-
-<p>Unhappy? <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete %></p>
-
-<%= link_to "Back", :back %>


### PR DESCRIPTION
- liタグの点を削除
- password,password_confirmationのアップデートを許可
- user_paramsにpassword,password_confirmationを追加
- sign_upのインデント修正
- ヘッダーにユーザー設定のリンク追加
- ユーザーの設定変更のビューを追加

既知の不具合
- パスワードの再設定を失敗するとビューが少し崩れる（どうやらエラーメッセージを表示しようとしている？）
- パスワードの再設定後、再ログインを求められる。再ログイン後に未実装のuser#showに飛ぶため、エラー画面が出る。（current_user.update_with_passwordヘルパーの仕様。変更可能かは未確認）
  - devise のマニュアルを読めば解決できるかもだが後回しにしたい。